### PR TITLE
turn on bias correction for amsua ch14 and atms ch15

### DIFF
--- a/sidb/iuseClass-4_channels.tbl
+++ b/sidb/iuseClass-4_channels.tbl
@@ -134,7 +134,10 @@ n18  20051001 000000  20071116 120000  amsua  1        14               # M2: re
 ###                                                                                             # attempt to assimilate.  This should be set
 ###                                                                                             # to inactive should an issue arise (wm)
 n18  20051101 000000  20071116 120000  amsua  1        14               # (old note)added all 14 back (see iuse-4.tbl)
-n18  20071116 180000  21001231 240000  amsua  1        14               # amsua: 9 bad, added all 14 back
+n18  20071116 180000  20230912 240000  amsua  1        14               # amsua: 9 bad, added all 14 back
+n18  20230913 000000  20231027 060000  amsua  0                         # NOAA-18 satellite will be fully transitioned to Parsons
+n18  20231027 120000  20241002 240000  amsua  1        14               # Transition complete
+n18  20241003 120000  21001231 240000  amsua  0                         # Bias correct ch14
 
 # NOAA-19 (nn')
 #==============
@@ -143,7 +146,8 @@ n19  20090414 000000  20091215 060000  amsua  1        14               # M2: re
 ###                                                                                             # attempt to assimilate.  This should be set
 ###                                                                                             # to inactive should an issue arise (wm)
 n19  20091215 120000  20091221 240000  amsua  1        14               #
-n19  20091222 000000  21001231 240000  amsua  1        14               #  ch8 noisy (noise started on 12/21/2009) 
+n19  20091222 000000  20241002 240000  amsua  1        14               # ch8 noisy (noise started on 12/21/2009) 
+n19  20241003 000000  21001231 240000  amsua  0                         # Bias correct ch14
 
 # Aqua AMSU-A
 #=============
@@ -161,14 +165,27 @@ metop-a 20210918 120000  21001231 240000  amsua 0
 
 # METOP-B
 #=========
-metop-b 20130213 000000  21001231 240000  amsua  1     14            # active for e512a_rt - known tech ok to be on
+metop-b 20130213 000000  20241002 240000  amsua  1     14            # active for e512a_rt - known tech ok to be on
+metop-b 20241003 000000  21001231 240000  amsua  0                   # Bias correct ch14
 
 # METOP-C   # using start data of data in regular data files - can modify this to reflect additional data availability
 #=========
-metop-c 20190917 000000  21001231 240000  amsua  1     14            # 
+metop-c 20190917 000000  20241002 240000  amsua  1     14            # 
+metop-c 20241003 000000  21001231 240000  amsua  0                   # Bias correct ch14
 
 
 # Downgrade & upgrade 14 to iuse=4
-npp  20111116 000000  21001231 240000  atms  1  15
-n20  20180510 000000  21001231 240000  atms  1  15
+npp  20111116 000000  20220727 240000  atms  1  15
+npp  20220728 000000  20220825 120000  atms  0
+npp  20220825 180000  20231101 120000  atms  1  15
+npp  20231101 180000  20231103 240000  atms  0    # safe mode
+npp  20231104 000000  20241002 240000  atms  1  15
+npp  20241003 000000  21001231 240000  atms  0         # Bias correct ch15
 
+n20  20180510 000000  20230929 120000  atms  1  15
+n20  20230929 180000  20231006 060000  atms  0         # Safe mode.
+n20  20231006 120000  20241002 240000  atms  1  15
+n20  20241003 120000  21001231 240000  atms  0         # Bias correct ch15
+
+n21  20230920 120000  20241002 240000  atms  1  15
+n21  20241003 120000  21001231 240000  atms  0         # Bias correct ch15


### PR DESCRIPTION
AMSU-A channel 14 and ATMS channel 15 have been used without bias correction (BC) in GEOS. Experiments have been conducted to compare the forecast skills among three configurations for these two channels: active but without BC, passive, and active with BC. The experiments showed favorable results for the configuration of active with BC.  This PR is made for the changes needed to turn on bias correction for AMSUA ch14 and ATMS ch15, so any further assessment experiments could be conducted.