### PR TITLE
revise for FP 5.42x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+16May2025:
+
+- Revise OMPS-LP for FPP/FP settings
+
+----------
+
 - add Metop-C AVHRR3 from late Jan 2025 onward
 
 ### Changed

--- a/ObsClass/obsys-nccs.rc
+++ b/ObsClass/obsys-nccs.rc
@@ -125,7 +125,8 @@
 #+  npp_ompsnp_bufr:   OMPS PM bufr format
 #+  npp_ompsnmeff_nc:  OMPS AM netcdf format
 #+  npp_ompsnp_nc:     OMPS PM netcdf format
-#+  npp_ompslp_nc:     OMPS Limb Profilers
+#+  npp_ompslp_nc:     OMPS Limb Profilers (NPP)
+#+  n21_ompslp_nc:     OMPS Limb Profilers (N21)
 #+  r21c_npp_ompslp_nc: M21C-OMPS NPP Limb Profilers
 #+  m2scr_n21_ompslp_nc: M2Scream-OMPS N21 Limb Profilers
 #+  aura_omieff_nc:    AURA OMI netcdf format
@@ -423,12 +424,16 @@ BEGIN npp_ompsnp_nc => ompsnpnc.%y4%m2%d2.t%h2z.nc
  20120201_00z-21001231_18z 060000  /discover/nobackup/projects/gmao/input/dao_ops/ops/reanalysis/ompsnp/Y%y4/M%m2/OMPSNP.%y4%m2%d2_%h2z.nc
 END
 
-BEGIN npp_ompslp_nc => ompslpnc.%y4%m2%d2.t%h2z.nc
+BEGIN npp_ompslp_nc => ompslpnppnc.%y4%m2%d2.t%h2z.nc
  20230904_00z-20240604_18z 060000  /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/ompslp/Y%y4/M%m2/OMPS-LPoz-v2.6-adj.%y4%m2%d2_%h2z.nc
  20240605_00z-20240611_18z 060000  /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/ompslp/Y%y4/M%m2/OMPS-LPoz-v2.6-adj.%y4%m2%d2_%h2z.nc_FP
  20240612_00z-20240708_18z 060000  /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/ompslp/Y%y4/M%m2/OMPS-LPoz-v2.6-adj.%y4%m2%d2_%h2z.nc
  20240709_00z-20240709_18z 060000  /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/ompslp/Y%y4/M%m2/OMPS-LPoz-v2.6-adj.%y4%m2%d2_%h2z.nc_FP
  20240710_00z-21001231_18z 060000  /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/ompslp/Y%y4/M%m2/OMPS-LPoz-v2.6-adj.%y4%m2%d2_%h2z.nc
+END
+
+BEGIN n21_ompslp_nc => ompslpn21nc.%y4%m2%d2.t%h2z.nc
+ 20250115_00z-21001231_18z 060000  /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/ompslp/Y%y4/M%m2/OMPS-LPoz-v1.0-n21-adj.%y4%m2%d2_%h2z.nc
 END
 
 # OMPS Limb Profiler profiles (version 2.6)

--- a/sidb/active_channels.tbl
+++ b/sidb/active_channels.tbl
@@ -385,7 +385,8 @@ n18  20150923 000000  20151012 240000  amsua  9        4 5 6 7     10 11 12 13 1
 n18  20151013 000000  20230911 240000  amsua  8        4   6 7     10 11 12 13 14               # ch 5 noisier
 n18  20230912 000000  20231024 240000  amsua  0                                                 # NOAA-18 satellite will be fully transitioned to Parsons
 n18  20231025 000000  20240621 060000  amsua  8        4   6 7     10 11 12 13 14               # Transition complete
-n18  20240621 120000  21001231 240000  amsua  7        4   6 7     10 11 12 13                  # Noisy channel 14 (all sats)
+n18  20240621 120000  20241231 240000  amsua  7        4   6 7     10 11 12 13                  # Noisy channel 14 (all sats)
+n18  20250101 000000  21001231 240000  amsua  8        4   6 7     10 11 12 13 14               # Chn14 back (used at ECMWF)
 
 n18  20051101 000000  20230911 240000  mhs    5  1 2 3 4 5 					#
 n18  20230912 000000  20231024 240000  mhs    0                                                 # NOAA-18 satellite will be fully transitioned to Parsons
@@ -412,7 +413,8 @@ n19  20090414 000000  20091215 060000  amsua 11        4 5 6 7 8 9 10 11 12 13 1
 n19  20091215 120000  20091221 240000  amsua 11        4 5 6 7 8 9 10 11 12 13 14               #
 n19  20091222 000000  20140128 240000  amsua 10        4 5 6 7   9 10 11 12 13 14               #  ch8 noisy (noise started on 12/21/2009)
 n19  20140129 000000  20240621 060000  amsua  9        4 5 6     9 10 11 12 13 14               #  per NCEP r35918
-n19  20240621 120000  21001231 240000  amsua  8        4 5 6     9 10 11 12 13                  #  Noisy channel 14 (all sats)
+n19  20240621 120000  20241231 240000  amsua  8        4 5 6     9 10 11 12 13                  #  Noisy channel 14 (all sats)
+n19  20250101 000000  21001231 240000  amsua  9        4 5 6     9 10 11 12 13 14               #  Chn14 back (used at ECMWF)
 
 n19  20090414 120000  21001231 240000  mhs    0
 
@@ -443,7 +445,8 @@ metop-b 20130213 000000  21001231 240000  hirs4  0                              
 
 metop-b 20130213 000000  20160924 240000  amsua 11        4 5 6 7 8 9 10 11 12 13 14           # active for e512a_rt-parallel testing
 metop-b 20160925 000000  20240621 060000  amsua  8              7 8 9 10 11 12 13 14           # ch 15 failure, only assimilate upper channels
-metop-b 20240621 120000  21001231 240000  amsua  7              7 8 9 10 11 12 13              # Noisy channel 14 (all sats)
+metop-b 20240621 120000  20241231 240000  amsua  7              7 8 9 10 11 12 13              # Noisy channel 14 (all sats)
+metop-b 20250101 000000  21001231 240000  amsua  8              7 8 9 10 11 12 13 14           # Chn14 back (used at ECMWF)
 
 metop-b 20130213 000000  20230602 060000  mhs    5  1 2 3 4 5                                  # active for e512a_rt-parallel testing
 metop-b 20230602 120000  20230628 240000  mhs    0                                             # instrument down or unstable
@@ -457,10 +460,12 @@ metop-b 20210918 120000  21001231 240000  avhrr3 2        4 5        #  MetOp-A 
 metop-c 20190917 000000  20231004 240000  amsua 11        4 5 6 7 8 9 10 11 12 13 14           # active for parallel testing
 metop-c 20231005 000000  20231026 240000  amsua  8              7 8 9 10 11 12 13 14           # reduction in accepted obs, noise, due to data drop-outs of ch4
 metop-c 20231027 000000  20240621 060000  amsua 11        4 5 6 7 8 9 10 11 12 13 14           # data drop-outs ended on 10/24
-metop-c 20240621 120000  21001231 240000  amsua 10        4 5 6 7 8 9 10 11 12 13              # Noisy channel 14 (all sats)
+metop-c 20240621 120000  20241231 240000  amsua 10        4 5 6 7 8 9 10 11 12 13              # Noisy channel 14 (all sats)
+metop-c 20250101 000000  21001231 240000  amsua 10        4 5 6 7   9 10 11 12 13 14           # Noisy chn8/chn14 back (used at ECMWF)
 
 metop-c 20190917 000000  21001231 240000  mhs    5  1 2 3 4 5                                  # active for parallel testing
 metop-c 20250131 120000  21001231 240000  avhrr3 2        4 5
+
 #======
 # SSM/I
 #======
@@ -773,12 +778,14 @@ n20  20230930 000000  20231002 240000  atms   0                                 
 n20  20231003 000000  20240321 120000  atms  17         5 6 7 8 9 10 11 12 13 14 15    17 18 19 20 21 22
 n20  20240321 180000  20240408 060000  atms   0                                                            # N-20 maneuver
 n20  20240408 120000  20240621 060000  atms  17         5 6 7 8 9 10 11 12 13 14 15    17 18 19 20 21 22
-n20  20240621 120000  21001231 240000  atms  16         5 6 7 8 9 10 11 12 13 14       17 18 19 20 21 22   # Noisy channel 15 (all sats)
+n20  20240621 120000  20241231 240000  atms  16         5 6 7 8 9 10 11 12 13 14       17 18 19 20 21 22   # Noisy channel 15 (all sats)
+n20  20250101 000000  21001231 240000  atms  17         5 6 7 8 9 10 11 12 13 14 15    17 18 19 20 21 22   # Chn15 back (used at ECMWF)
 
 n21  20230920 120000  20240621 060000  atms  17         5 6 7 8 9 10 11 12 13 14 15    17 18 19 20 21 22
 n21  20240621 120000  20240720 000000  atms  16         5 6 7 8 9 10 11 12 13 14       17 18 19 20 21 22   # Noisy channel 15 (all sats)
 n21  20240720 060000  20240720 180000  atms   0                                                            # Geolocation problem
-n21  20240721 000000  21001231 240000  atms  16         5 6 7 8 9 10 11 12 13 14       17 18 19 20 21 22
+n21  20240721 000000  20241231 240000  atms  16         5 6 7 8 9 10 11 12 13 14       17 18 19 20 21 22
+n21  20250101 000000  21001231 240000  atms  17         5 6 7 8 9 10 11 12 13 14 15    17 18 19 20 21 22   # Chn15 back (used at ECMWF)
 
 # cris active channels                           m       01    02    03    04    05    06    07    08    09    10
 npp  20171020 000000  20190325 180000 cris-fsr   9             57    58    59    60    61    62    63    64    65


### PR DESCRIPTION
Minor revision to add OMPS-LP to FPP/FP settings. Zero diff is not using it.