### PR TITLE
OMI and METOPC AMSUS upds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+22May2025:
+- chn 4-6 of AMSUA MetopC should have been turned off after a given date.
+
+- it was also found out on May 22 that EMC is no longer delivering the version of bufr 
+  OMI being used in FP; so changes here move the pointer to OMIEFF being used in 
+  GEOS-IT (this is a real time version of the data).
+
 21May2025:
 
 - turn chn 15 of ATMS NPP back on

--- a/ObsClass/obsys-nccs.rc
+++ b/ObsClass/obsys-nccs.rc
@@ -445,7 +445,8 @@ BEGIN m2scr_n21_ompslp_nc => ompslpnc_n21.%y4%m2%d2.t%h2z.nc
 END
 
 BEGIN aura_omieff_nc => omieff.%y4%m2%d2.t%h2z.nc
- 20041001_00z-21001231_18z 060000 /discover/nobackup/projects/gmao/input/dao_ops/ops/reanalysis/omi_eff_adjusted/Y%y4/M%m2/OMIeff-adj.%y4%m2%d2_%h2z.nc
+ 20041001_00z-20240608_18z 060000 /discover/nobackup/projects/gmao/input/dao_ops/ops/reanalysis/omi_eff_adjusted/Y%y4/M%m2/OMIeff-adj.%y4%m2%d2_%h2z.nc
+ 20240609_00z-21001231_18z 060000  /discover/nobackup/projects/gmao/input/dao_ops/ops/reanalysis/omi_eff_adjusted_CORRECTED_nrt/Y%y4/M%m2/OMIeff-adj-nrt.%y4%m2%d2_%h2z.nc
 END
 
 # MLS retrieved temperature

--- a/ozinfo.db/active.tbl
+++ b/ozinfo.db/active.tbl
@@ -46,9 +46,10 @@ aura      20041001 000000  29991231 240000   o3lev         7   38 39 40 41 42 43
 aura      20130401 000000  29991231 240000   mls55     29       9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37
 aura      20130401 000000  29991231 240000   mls55      6   38 39 40 41 42 43
 
-# Note that redundency of the same data is allowed software.  One has to edit either time range of active.tbl or gsi.rc to explude one or another.
+# Note that redundancy of the same data is allowed in software.  One has to edit either time range of active.tbl or gsi.rc to expose one or another.
 # aura ozone levels (omi .xor. omieff)               count  -- levels --
 aura      19900101 000000  29901231 240000   omi         1       1
+aura      19900101 000000  20250521 240000   omi         1       1   # EMC no-longer delivers this type; so better use omieff
 aura      20041001 000000  29991231 240000   omieff      1       1
 
 # toms                                               count  -- levels --

--- a/sidb/active_channels.tbl
+++ b/sidb/active_channels.tbl
@@ -461,7 +461,8 @@ metop-c 20190917 000000  20231004 240000  amsua 11        4 5 6 7 8 9 10 11 12 1
 metop-c 20231005 000000  20231026 240000  amsua  8              7 8 9 10 11 12 13 14           # reduction in accepted obs, noise, due to data drop-outs of ch4
 metop-c 20231027 000000  20240621 060000  amsua 11        4 5 6 7 8 9 10 11 12 13 14           # data drop-outs ended on 10/24
 metop-c 20240621 120000  20241231 240000  amsua 10        4 5 6 7 8 9 10 11 12 13              # Noisy channel 14 (all sats)
-metop-c 20250101 000000  21001231 240000  amsua 10        4 5 6 7   9 10 11 12 13 14           # Noisy chn8/chn14 back (used at ECMWF)
+metop-c 20250101 000000  20250122 240000  amsua 10        4 5 6 7   9 10 11 12 13 14           # Noisy chn8/chn14 back (used at ECMWF)
+metop-c 20250123 000000  21001231 240000  amsua  7              7   9 10 11 12 13 14           # Noisy chn4-6
 
 metop-c 20190917 000000  21001231 240000  mhs    5  1 2 3 4 5                                  # active for parallel testing
 metop-c 20250131 120000  21001231 240000  avhrr3 2        4 5


### PR DESCRIPTION
In trying to come up with a 5.42 version of ADAS for FPP it was found that:

- chn 4-6 of AMSUA MetopC should have been turned off after a given date.

- it was also found out on May 22 that EMC is no longer delivering the version of bufr OMI being used in FP; so changes here  move the pointer to OMIEFF being used in GEOS-IT (this is a real time version of the data).

These changes are clearly not zero diff - unavoidably so.