### PR TITLE
Update AERONET LLK location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+08Jan2026:
+- update location of LLK AERONET files 
+
 15Jul2025:
 - add class-location of hi-res RAOB
 

--- a/ObsClass/obsys-nccs-gaas.rc
+++ b/ObsClass/obsys-nccs-gaas.rc
@@ -134,5 +134,5 @@ BEGIN aeronet_obs_flk => aeronet.obs.%y4%m2%d2_%h2z.ods
 END
 BEGIN aeronet_obs_llk => aeronet.obs.%y4%m2%d2_%h2z.ods
   19950317_18z-20231231_21z 030000 /discover/nobackup/projects/gmao/input/dao_ops/ops/reanalysis/aerosol/data/AERONET.v3/Level2/ODS/Y%y4/M%m2/aeronet.obs.%y4%m2%d2_%h2z.ods
-  20240101_00z-21000101_00z 030000 /discover/nobackup/dao_ops/intermediate/flk/stage/aeronet/aeronet.obs.%y4%m2%d2_%h2z.ods
+  20240101_00z-21000101_00z 030000 /discover/nobackup/projects/gmao/input/dao_ops/ops/reanalysis/aerosol/data/AERONET_NRT/Level2/ODS/Y%y4/M%m2/aeronet.obs.%y4%m2%d2_%h2z.ods
 END


### PR DESCRIPTION
This points LLK AERONET location to more permanent space as opposed to intermediate location used in FP.

Zero-diff to GEOSadas v5.42.8.