### PR TITLE
End MODIS; Begin VIIRS for x0054

### DIFF
--- a/ObsClass/obsys-nccs-gaas.rc
+++ b/ObsClass/obsys-nccs-gaas.rc
@@ -34,22 +34,22 @@ END
 # VIIRS NOAA-20 AERDT Level2 Data
 #--------------------------------
 BEGIN vn20aerdt_002_flk => VN20AERDT_L2_VIIRS_NOAA20.A%y4%j3.%h2%n2.002.nrt.nc
-  20250805_00z-21001231_18z 000600 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/VIIRS/Level2/VN20AERDT/002/%y4/%j3/AERDT_L2_VIIRS_NOAA20.A%y4%j3.%h2%n2.002.nrt.nc
+  20260201_00z-21001231_18z 000600 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/VIIRS/Level2/VN20AERDT/002/%y4/%j3/AERDT_L2_VIIRS_NOAA20.A%y4%j3.%h2%n2.002.nrt.nc
 END
 
 # VIIRS NOAA-20 AERDB Level2 Data
 #--------------------------------
 BEGIN vn20aerdb_002_flk => VN20AERDB_L2_VIIRS_NOAA20.A%y4%j3.%h2%n2.002.nrt.nc
-  20250101_00z-21001231_18z 000600 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/VIIRS/Level2/VN20AERDB/002/%y4/%j3/AERDB_L2_VIIRS_NOAA20.A%y4%j3.%h2%n2.002.nrt.nc
+  20260201_00z-21001231_18z 000600 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/VIIRS/Level2/VN20AERDB/002/%y4/%j3/AERDB_L2_VIIRS_NOAA20.A%y4%j3.%h2%n2.002.nrt.nc
 END
 
 # MODIS Terra Level2 Data
 #------------------------
 BEGIN mod04_061_flk => MOD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
-  20171101_00z-21001231_18z 000500 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/modis/061/MOD04/%y4/%j3/MOD04_L2.A%y4%j3.%h2%n2.061.%y4%j3%c%c%c%c%c%c.NRT.hdf
+  20171101_00z-20260131_18z 000500 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/modis/061/MOD04/%y4/%j3/MOD04_L2.A%y4%j3.%h2%n2.061.%y4%j3%c%c%c%c%c%c.NRT.hdf
 END
 BEGIN mod04_061_llk => MOD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
-  20171101_00z-21001231_18z 000500 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/modis/061/MOD04/%y4/%j3/MOD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
+  20171101_00z-20260131_18z 000500 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/modis/061/MOD04/%y4/%j3/MOD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
 END
 BEGIN mod04_061_arc => MOD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
   20171101_00z-21001231_18z 000500 /archive/input/dao_ops/obs/flk/modis.061/MOD04/%y4/%j3/MOD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
@@ -92,10 +92,10 @@ END
 # MODIS Aqua Level2 Data
 #-----------------------
 BEGIN myd04_061_flk => MYD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
-  20171101_00z-21001231_18z 000500 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/modis/061/MYD04/%y4/%j3/MYD04_L2.A%y4%j3.%h2%n2.061.%y4%j3%c%c%c%c%c%c.NRT.hdf
+  20171101_00z-20260131_18z 000500 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/modis/061/MYD04/%y4/%j3/MYD04_L2.A%y4%j3.%h2%n2.061.%y4%j3%c%c%c%c%c%c.NRT.hdf
 END
 BEGIN myd04_061_llk => MYD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
-  20171101_00z-21001231_18z 000500 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/modis/061/MYD04/%y4/%j3/MYD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
+  20171101_00z-20260131_18z 000500 /discover/nobackup/projects/gmao/input/dao_ops/ops/flk/modis/061/MYD04/%y4/%j3/MYD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
 END
 BEGIN myd04_061_arc => MYD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf
   20171101_00z-21001231_18z 000500 /archive/input/dao_ops/obs/flk/modis.061/MYD04/%y4/%j3/MYD04_L2.A%y4%j3.%h2%n2.061.NRT.hdf


### PR DESCRIPTION
This is in prep for ADAS 5.44.x - this stops the use of MODIS at the end of Jan 2026 and starts the use of VIIRS starting 1 Feb 2026.

Not zero diff to 5.43 - but intentionally so.